### PR TITLE
Fix for EMM-1672

### DIFF
--- a/modules/p2-profile-gen/pom.xml
+++ b/modules/p2-profile-gen/pom.xml
@@ -306,9 +306,6 @@
                                     org.wso2.carbon.identity:org.wso2.carbon.identity.oauth.common.feature:${carbon.identity.inbound.auth.oauth.version}
                                 </featureArtifactDef>
                                 <featureArtifactDef>
-                                    org.wso2.carbon.identity:org.wso2.carbon.identity.provider.server.feature:${carbon.identity-inbound-auth-openid.version}
-                                </featureArtifactDef>
-                                <featureArtifactDef>
                                     org.wso2.carbon.identity:org.wso2.carbon.identity.thrift.authentication.feature:${carbon.identity.framework.version}
                                 </featureArtifactDef>
                                 <featureArtifactDef>
@@ -880,10 +877,6 @@
                                 <feature>
                                     <id>org.wso2.carbon.identity.oauth.common.feature.group</id>
                                     <version>${carbon.identity.inbound.auth.oauth.version}</version>
-                                </feature>
-                                <feature>
-                                    <id>org.wso2.carbon.identity.provider.server.feature.group</id>
-                                    <version>${carbon.identity-inbound-auth-openid.version}</version>
                                 </feature>
                                 <feature>
                                     <id>org.wso2.carbon.identity.thrift.authentication.feature.group</id>
@@ -1479,10 +1472,6 @@
                                 <feature>
                                     <id>org.wso2.carbon.identity.oauth.common.feature.group</id>
                                     <version>${carbon.identity.inbound.auth.oauth.version}</version>
-                                </feature>
-                                <feature>
-                                    <id>org.wso2.carbon.identity.provider.server.feature.group</id>
-                                    <version>${carbon.identity-inbound-auth-openid.version}</version>
                                 </feature>
                                 <feature>
                                     <id>org.wso2.carbon.identity.thrift.authentication.feature.group</id>

--- a/pom.xml
+++ b/pom.xml
@@ -1023,7 +1023,6 @@
         <carbon.identity.framework.version.range>[5.2.1, 6.0.0)</carbon.identity.framework.version.range>
         <carbon.identity.inbound.auth.oauth.version>5.1.3</carbon.identity.inbound.auth.oauth.version>
         <carbon.identity-user-ws.version>5.1.1</carbon.identity-user-ws.version>
-        <carbon.identity-inbound-auth-openid.version>5.1.1</carbon.identity-inbound-auth-openid.version>
         <carbon.identity-local-auth-basicauth.version>5.1.1</carbon.identity-local-auth-basicauth.version>
         <carbon.identity-inbound-auth-saml2.version>5.1.2</carbon.identity-inbound-auth-saml2.version>
         <carbon.identity.inbound.auth.saml.version>5.1.1</carbon.identity.inbound.auth.saml.version>


### PR DESCRIPTION
This PR is related to [EMM-1672](https://wso2.org/jira/browse/EMM-1672)

This PR removes the deprecated `org.wso2.carbon.identity:org.wso2.carbon.identity.provider.server.feature` from the product.